### PR TITLE
bugfix/ECO-1284-fix-for-wrong-desabled-enabled-mapping-result

### DIFF
--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Mapper/Map/ProductImportMap.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Mapper/Map/ProductImportMap.php
@@ -23,6 +23,7 @@ class ProductImportMap extends AbstractMap
             'prices' => 'values.price',
             'images' => 'values.bild_information',
             'picto_images' => 'values.picto_informationen',
+            'is_active' => 'enabled',
             'attributes' => [
                 'values.attributes',
             ],


### PR DESCRIPTION
* added is_active atrribute with enabled value to ProductImportMap