### PR TITLE
CC-33265: Update of the Akeneo HTTP client library to support all latest versions.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text text=auto eol=lf
 
+*.php diff=php
+
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary
@@ -20,7 +22,6 @@
 *.exe binary
 
 # Remove files for archives generated using `git archive`
-architecture-baseline.json export-ignore
 dependency.json export-ignore
 phpstan.json export-ignore
 phpstan.neon export-ignore
@@ -31,3 +32,5 @@ tooling.yml export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.github/ export-ignore
+architecture-baseline.json export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,126 +1,52 @@
 name: CI
 
-env:
-    APPLICATION_ENV: 'development'
-    APPLICATION_STORE: 'DE'
-    PROJECT: 'Akeneo PIM Middleware Connector'
-    DATABASE_VERSION: 10.2
-    DATABASE_HOST: 127.0.0.1
-    DATABASE_PORT: 3306
-    DATABASE_NAME: eu-docker
-    DATABASE_USERNAME: root
-    DATABASE_PASSWORD: secret
-    DATABASE_ROOT_PASSWORD: secret
-    DATABASE_ALLOW_EMPTY_PASSWORD: false
-    DATABASE_CHARACTER_SET: utf8
-    DATABASE_COLLATE: utf8_general_ci
-
 on:
-    pull_request:
     push:
         branches:
             - 'master'
+    pull_request:
     workflow_dispatch:
 
 jobs:
-    setup:
-        name: Setup Database MariaDB
-        runs-on: ubuntu-22.04
+    validation:
+        name: Validation
+        runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v2
-            - uses: getong/mariadb-action@v1.1
-              with:
-                  host port: ${{ env.DATABASE_PORT }}
-                  container port: ${{ env.DATABASE_PORT }}
-                  character set server: ${{ env.DATABASE_CHARACTER_SET }}
-                  collation server: ${{ env.DATABASE_COLLATE }}
-                  mariadb version: ${{ env.DATABASE_VERSION }}
-                  mysql database: ${{ env.DATABASE_NAME }}
-                  mysql root password: ${{ env.DATABASE_ROOT_PASSWORD }}
-                  mysql user: ${{ env.DATABASE_USERNAME }}
-                  mysql password: ${{ env.DATABASE_PASSWORD }}
+            - uses: actions/checkout@v3
 
-    ci:
-        name: Akeneo PIM Middleware Connector (PHP ${{ matrix.php-versions }})
-        needs: setup
-        runs-on: ubuntu-22.04
-
-        strategy:
-            fail-fast: false
-            matrix:
-                php-versions:
-                    - '8.1'
-                    - '8.2'
-
-        services:
-            mariadb:
-                image: mariadb:10.2
-                env:
-                    MYSQL_ALLOW_EMPTY_PASSWORD: false
-                    MYSQL_ROOT_PASSWORD: secret
-                    MYSQL_DATABASE: eu-docker
-                ports:
-                    - 3306:3306
-                options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
-        steps:
-            - name: Checkout@v2
-              uses: actions/checkout@v2
-
-            - name: Setup PHP ${{ matrix.php-versions }}
+            - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ matrix.php-versions }}
-                  extensions: mbstring, intl, bcmath, pdo_mysql
+                  php-version: '8.2'
+                  extensions: mbstring, intl, bcmath
+                  coverage: none
 
-            - name: Get composer cache directory
-              id: composer-cache
-              run: |
-                  echo "::set-output name=dir::$(composer config cache-files-dir)"
-            - uses: actions/cache@v2
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-${{ matrix.php-versions }}-composer-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-${{ matrix.php-versions }}-composer-
+            - name: Composer Install
+              run: composer install --prefer-dist --no-interaction --profile
 
-            - name: Composer validate
+            - name: Run validation
               run: composer validate
 
-            - name: Composer version
-              run: composer --version
-
-            - name: Composer install
-              run: composer install --prefer-dist --no-interaction --optimize-autoloader
-
-            - name: PHP syntax validation
+            - name: Syntax check
               run: find ./src -path src -prune -o -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
 
     lowest:
-        name: Akeneo PIM Middleware Connector Prefer Lowest (PHP ${{ matrix.php-versions }})
-        runs-on: ubuntu-22.04
+        name: Prefer Lowest
+        runs-on: ubuntu-latest
 
         steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
                   php-version: '8.1'
-                  extensions: mbstring, intl, bcmath, pdo_mysql
+                  extensions: mbstring, intl, bcmath
+                  coverage: none
 
             - name: Composer Install
               run: composer install --prefer-dist --no-interaction --profile
 
             - name: Composer Update
               run: composer update --prefer-lowest --prefer-dist --no-interaction --profile -vvv
-
-            - name: Prefer lowest installation
-              run: composer require --dev dereuromark/composer-prefer-lowest;
-
-            - name: PHP syntax validation
-              run: find ./src -path src -prune -o -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
-
-            - name: Prefer lowest validation
-              run: vendor/bin/validate-prefer-lowest -m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
             fail-fast: false
             matrix:
                 php-versions:
-                    - '7.2'
+                    - '8.1'
                     - '8.2'
 
         services:
@@ -107,7 +107,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '7.2'
+                  php-version: '8.1'
                   extensions: mbstring, intl, bcmath, pdo_mysql
 
             - name: Composer Install

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,36 @@
-# IDEs
-/.idea
-/.project
-/nbproject
-/.buildpath
-/.settings
+# IDE
+.idea/
+.project/
+nbproject/
+.buildpath/
+.settings/
 *.sublime-*
+
+# OS
+.DS_Store
 *.AppleDouble
 *.AppleDB
 *.AppleDesktop
-/tests/SprykerEcoTest/Zed/AkeneoPimMiddlewareConnector/_support/_generated/*
 
+# grunt stuff
+.grunt
+.sass-cache
+/node_modules/
+
+# tooling
 vendor/
 composer.lock
+.phpunit.result.cache
+
+# built client resources
+src/*/Zed/*/Static/Public
+src/*/Zed/*/Static/Assets/sprite
+
+# Propel classes
+src/*/Zed/*/Persistence/Propel/Base/*
+src/*/Zed/*/Persistence/Propel/Map/*
+
+# tests
+tests/**/_generated/
+tests/_output/*
+!tests/_output/.gitkeep

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 build:
     environment:
-        php: '7.2'
+        php: '8.1'
 
     tests:
         override:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://scrutinizer-ci.com/g/spryker-eco/akeneo-pim-middleware-connector/badges/build.png?b=master)](https://scrutinizer-ci.com/g/spryker-eco/akeneo-pim-middleware-connector/build-status/master)
 [![Latest Stable Version](https://poser.pugx.org/spryker-eco/akeneo-pim-middleware-connector/v/stable.svg)](https://packagist.org/packages/spryker-eco/akeneo-pim-middleware-connector)
 [![License](https://img.shields.io/github/license/spryker-eco/akeneo-pim-middleware-connector.svg?b=master)](https://github.com/spryker-eco/akeneo-pim-middleware-connector)
-[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%207.2-8892BF.svg)](https://php.net/)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # AkeneoPimMiddlewareConnector Module
 
 [![CI](https://github.com/spryker-eco/akeneo-pim-middleware-connector/actions/workflows/ci.yml/badge.svg)](https://github.com/spryker-eco/akeneo-pim-middleware-connector/actions/workflows/ci.yml)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/spryker-eco/akeneo-pim-middleware-connector/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/spryker-eco/akeneo-pim-middleware-connector/?branch=master)
-[![Build Status](https://scrutinizer-ci.com/g/spryker-eco/akeneo-pim-middleware-connector/badges/build.png?b=master)](https://scrutinizer-ci.com/g/spryker-eco/akeneo-pim-middleware-connector/build-status/master)
+
+[![CI](https://scrutinizer-ci.com/g/spryker-eco/akeneo-pim-middleware-connector/badges/build.png?b=master)](https://scrutinizer-ci.com/g/spryker-eco/akeneo-pim-middleware-connector/build-status/master)
 [![Latest Stable Version](https://poser.pugx.org/spryker-eco/akeneo-pim-middleware-connector/v/stable.svg)](https://packagist.org/packages/spryker-eco/akeneo-pim-middleware-connector)
 [![License](https://img.shields.io/github/license/spryker-eco/akeneo-pim-middleware-connector.svg?b=master)](https://github.com/spryker-eco/akeneo-pim-middleware-connector)
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.1-8892BF.svg)](https://php.net/)

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,23 @@
 {
     "name": "spryker-eco/akeneo-pim-middleware-connector",
-    "description": "AkeneoPimMiddlewareConnector module",
     "type": "library",
+    "description": "AkeneoPimMiddlewareConnector module",
     "license": "proprietary",
     "require": {
         "php": ">=7.2",
+        "spryker-eco/akeneo-pim": "^2.2.0",
+        "spryker-middleware/process": "^1.0.0",
         "spryker/kernel": "^3.30.0",
         "spryker/locale": "^3.0.0 || ^4.0.0",
+        "spryker/product": "^5.0.0 || ^6.0.0",
+        "spryker/propel-orm": "^1.0.0",
         "spryker/tax": "^5.0.0",
-        "spryker-eco/akeneo-pim": "^2.0.0",
-        "spryker-middleware/process": "^1.0.0",
-        "spryker/data-import": "^1.0.0"
+        "spryker/url": "^3.0.0",
+        "spryker/util-text": "^1.0.0"
+    },
+    "require-dev": {
+        "spryker/code-sniffer": "*",
+        "spryker/testify": "*"
     },
     "autoload": {
         "psr-4": {
@@ -18,13 +25,13 @@
             "SprykerEcoTest\\Zed\\AkeneoPimMiddlewareConnector\\Helper\\": "tests/SprykerEcoTest/Zed/AkeneoPimMiddlewareConnector/_support/Helper/"
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "autoload-dev": {
         "psr-4": {
             "SprykerEcoTest\\": "tests/SprykerEcoTest/"
         }
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "scripts": {
         "cs-check": "phpcs -p -s --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src/ tests/",
         "cs-fix": "phpcbf -p --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src/ tests/"
@@ -35,6 +42,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "AkeneoPimMiddlewareConnector module",
     "license": "proprietary",
     "require": {
-        "php": ">=7.2",
+        "php": ">=8.1",
         "spryker-eco/akeneo-pim": "^2.2.0",
         "spryker-middleware/process": "^1.0.0",
         "spryker/kernel": "^3.30.0",
@@ -34,7 +34,9 @@
     "prefer-stable": true,
     "scripts": {
         "cs-check": "phpcs -p -s --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src/ tests/",
-        "cs-fix": "phpcbf -p --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src/ tests/"
+        "cs-fix": "phpcbf -p --standard=vendor/spryker/code-sniffer/Spryker/ruleset.xml src/ tests/",
+        "stan": "phpstan analyse -c phpstan.neon -l 8 src/",
+        "stan-setup": "cp composer.json composer.backup && COMPOSER_MEMORY_LIMIT=-1 composer require --dev phpstan/phpstan:^0.12 && mv composer.backup composer.json"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "spryker/util-text": "^1.0.0"
     },
     "require-dev": {
+        "phpstan/phpstan": "^1.0.0",
         "spryker/code-sniffer": "*",
         "spryker/testify": "*"
     },

--- a/src/SprykerEco/Shared/AkeneoPimMiddlewareConnector/AkeneoPimMiddlewareConnectorConstants.php
+++ b/src/SprykerEco/Shared/AkeneoPimMiddlewareConnector/AkeneoPimMiddlewareConnectorConstants.php
@@ -12,13 +12,48 @@ namespace SprykerEco\Shared\AkeneoPimMiddlewareConnector;
  */
 interface AkeneoPimMiddlewareConnectorConstants
 {
+    /**
+     * @var string
+     */
     public const LOCALE_MAP_FILE_PATH = 'AKENEOPIMMIDDLEWARECONNECTOR:LOCALE_MAP_FILE_PATH';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_MAP_FILE_PATH = 'AKENEOPIMMIDDLEWARECONNECTOR:ATTRIBUTE_MAP_FILE_PATH';
+
+    /**
+     * @var string
+     */
     public const SUPER_ATTRIBUTE_MAP_FILE_PATH = 'AKENEOPIMMIDDLEWARECONNECTOR:SUPER_ATTRIBUTE_MAP_FILE_PATH';
+
+    /**
+     * @var string
+     */
     public const FK_CATEGORY_TEMPLATE = 'AKENEOPIMMIDDLEWARECONNECTOR:FK_CATEGORY_TEMPLATE';
+
+    /**
+     * @var string
+     */
     public const TAX_SET = 'AKENEOPIMMIDDLEWARECONNECTOR:TAX_SET';
+
+    /**
+     * @var string
+     */
     public const LOCALES_FOR_IMPORT = 'AKENEOPIMMIDDLEWARECONNECTOR:LOCALES_FOR_IMPORT';
+
+    /**
+     * @var string
+     */
     public const LOCALES_TO_PRICE_MAP = 'AKENEOPIMMIDDLEWARECONNECTOR:LOCALES_TO_PRICE_MAP';
+
+    /**
+     * @var string
+     */
     public const ACTIVE_STORES_FOR_PRODUCTS = 'AKENEOPIMMIDDLEWARECONNECTOR:ACTIVE_STORES_FOR_PRODUCTS';
+
+    /**
+     * @var string
+     */
     public const DEFAULT_PARENT_CATEGORY_KEY = 'AKENEOPIMMIDDLEWARECONNECTOR:DEFAULT_PARENT_CATEGORY_KEY';
 }

--- a/src/SprykerEco/Shared/AkeneoPimMiddlewareConnector/Transfer/akeneo_pim_middleware_connector.transfer.xml
+++ b/src/SprykerEco/Shared/AkeneoPimMiddlewareConnector/Transfer/akeneo_pim_middleware_connector.transfer.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<transfers xmlns="spryker:transfer-01"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="spryker:transfer-01 http://static.spryker.com/transfer-01.xsd">
+
+    <transfer name="MapperConfig">
+    </transfer>
+
+    <transfer name="TranslatorConfig">
+    </transfer>
+
+    <transfer name="ValidatorConfig">
+    </transfer>
+
+</transfers>

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/AkeneoPimMiddlewareConnectorConfig.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/AkeneoPimMiddlewareConnectorConfig.php
@@ -13,6 +13,8 @@ use SprykerEco\Shared\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorC
 class AkeneoPimMiddlewareConnectorConfig extends AbstractBundleConfig
 {
     /**
+     * @api
+     *
      * @return string
      */
     public function getLocaleMapFilePath(): string
@@ -21,6 +23,8 @@ class AkeneoPimMiddlewareConnectorConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getAttributeMapFilePath(): string
@@ -29,6 +33,8 @@ class AkeneoPimMiddlewareConnectorConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getSuperAttributeMapFilePath(): string
@@ -37,6 +43,8 @@ class AkeneoPimMiddlewareConnectorConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return int
      */
     public function getFkCategoryTemplate(): int
@@ -45,6 +53,8 @@ class AkeneoPimMiddlewareConnectorConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
     public function getTaxSet(): string
@@ -53,6 +63,8 @@ class AkeneoPimMiddlewareConnectorConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return array
      */
     public function getLocalesForImport(): array
@@ -61,6 +73,8 @@ class AkeneoPimMiddlewareConnectorConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return array
      */
     public function getActiveStoresForProducts(): array
@@ -69,6 +83,8 @@ class AkeneoPimMiddlewareConnectorConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return array
      */
     public function getLocaleToPriceMap(): array
@@ -77,9 +93,11 @@ class AkeneoPimMiddlewareConnectorConfig extends AbstractBundleConfig
     }
 
     /**
+     * @api
+     *
      * @return string
      */
-    public function getDefaultParentCategoryKey() : string
+    public function getDefaultParentCategoryKey(): string
     {
         return $this->get(AkeneoPimMiddlewareConnectorConstants::DEFAULT_PARENT_CATEGORY_KEY, 'demoshop');
     }

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/AkeneoPimMiddlewareConnectorDependencyProvider.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/AkeneoPimMiddlewareConnectorDependencyProvider.php
@@ -89,103 +89,414 @@ use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamReaderStagePlugin;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\StreamWriterStagePlugin;
 use SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ */
 class AkeneoPimMiddlewareConnectorDependencyProvider extends AbstractBundleDependencyProvider
 {
+    /**
+     * @var string
+     */
     public const SERVICE_AKENEO_PIM = 'SERVICE_AKENEO_PIM';
+
+    /**
+     * @var string
+     */
     public const SERVICE_UTIL_TEXT = 'SERVICE_UTIL_TEXT';
+
+    /**
+     * @var string
+     */
     public const FACADE_PROCESS = 'FACADE_PROCESS';
+
+    /**
+     * @var string
+     */
     public const FACADE_PRODUCT = 'FACADE_PRODUCT';
 
+    /**
+     * @var string
+     */
     public const DEFAULT_AKENEO_PIM_MIDDLEWARE_PROCESSES = 'DEFAULT_AKENEO_PIM_MIDDLEWARE_PROCESSES';
+
+    /**
+     * @var string
+     */
     public const DEFAULT_AKENEO_PIM_MIDDLEWARE_TRANSLATOR_FUNCTIONS = 'DEFAULT_AKENEO_PIM_MIDDLEWARE_TRANSLATOR_FUNCTIONS';
 
+    /**
+     * @var string
+     */
     public const PRODUCT_ABSTRACT_QUERY = 'PRODUCT_ABSTRACT_QUERY';
 
+    /**
+     * @var string
+     */
     public const URL_GENERATOR_STRATEGY = 'URL_GENERATOR_STRATEGY';
 
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_PROCESSES = 'AKENEO_PIM_MIDDLEWARE_PROCESSES';
+
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_LOGGER_CONFIG = 'AKENEO_PIM_MIDDLEWARE_LOGGER_CONFIG';
+
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_TRANSLATOR_FUNCTIONS = 'AKENEO_PIM_MIDDLEWARE_TRANSLATOR_FUNCTIONS';
+
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_VALIDATORS = 'AKENEO_PIM_MIDDLEWARE_VALIDATORS';
+
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_CATEGORY_IMPORTER_PLUGIN = 'AKENEO_PIM_MIDDLEWARE_CATEGORY_IMPORTER_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_ATTRIBUTE_IMPORTER_PLUGIN = 'AKENEO_PIM_MIDDLEWARE_ATTRIBUTE_IMPORTER_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_PRODUCT_ABSTRACT_IMPORTER_PLUGIN = 'AKENEO_PIM_MIDDLEWARE_PRODUCT_ABSTRACT_IMPORTER_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_PRODUCT_CONCRETE_IMPORTER_PLUGIN = 'AKENEO_PIM_MIDDLEWARE_PRODUCT_CONCRETE_IMPORTER_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_PRODUCT_PRICE_IMPORTER_PLUGIN = 'AKENEO_PIM_MIDDLEWARE_PRODUCT_PRICE_IMPORTER_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const AKENEO_PIM_MIDDLEWARE_PRODUCT_ABSTRACT_STORES_IMPORTER_PLUGIN = 'AKENEO_PIM_MIDDLEWARE_PRODUCT_ABSTRACT_STORES_IMPORTER_PLUGIN';
 
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_IMPORT_INPUT_STREAM_PLUGIN = 'ATTRIBUTE_IMPORT_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_IMPORT_OUTPUT_STREAM_PLUGIN = 'ATTRIBUTE_IMPORT_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_IMPORT_ITERATOR_PLUGIN = 'ATTRIBUTE_IMPORT_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_IMPORT_STAGE_PLUGINS = 'ATTRIBUTE_IMPORT_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_IMPORT_PRE_PROCESSOR_PLUGINS = 'ATTRIBUTE_IMPORT_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_IMPORT_POST_PROCESSOR_PLUGINS = 'ATTRIBUTE_IMPORT_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_MAP_INPUT_STREAM_PLUGIN = 'ATTRIBUTE_MAP_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_MAP_OUTPUT_STREAM_PLUGIN = 'ATTRIBUTE_MAP_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_MAP_ITERATOR_PLUGIN = 'ATTRIBUTE_MAP_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_MAP_STAGE_PLUGINS = 'ATTRIBUTE_MAP_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_MAP_PRE_PROCESSOR_PLUGINS = 'ATTRIBUTE_MAP_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_MAP_POST_PROCESSOR_PLUGINS = 'ATTRIBUTE_MAP_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const CATEGORY_IMPORT_INPUT_STREAM_PLUGIN = 'CATEGORY_IMPORT_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const CATEGORY_IMPORT_OUTPUT_STREAM_PLUGIN = 'CATEGORY_IMPORT_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const CATEGORY_IMPORT_ITERATOR_PLUGIN = 'CATEGORY_IMPORT_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const CATEGORY_IMPORT_STAGE_PLUGINS = 'CATEGORY_IMPORT_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const CATEGORY_IMPORT_PRE_PROCESSOR_PLUGINS = 'CATEGORY_IMPORT_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const CATEGORY_IMPORT_POST_PROCESSOR_PLUGINS = 'CATEGORY_IMPORT_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const LOCALE_MAP_IMPORT_INPUT_STREAM_PLUGIN = 'LOCALE_MAP_IMPORT_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const LOCALE_MAP_IMPORT_OUTPUT_STREAM_PLUGIN = 'LOCALE_MAP_IMPORT_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const LOCALE_MAP_IMPORT_ITERATOR_PLUGIN = 'LOCALE_MAP_IMPORT_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const LOCALE_MAP_IMPORT_STAGE_PLUGINS = 'LOCALE_MAP_IMPORT_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const LOCALE_MAP_IMPORT_PRE_PROCESSOR_PLUGINS = 'LOCALE_MAP_IMPORT_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const LOCALE_MAP_IMPORT_POST_PROCESSOR_PLUGINS = 'LOCALE_MAP_IMPORT_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const PRODUCT_IMPORT_INPUT_STREAM_PLUGIN = 'PRODUCT_IMPORT_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_IMPORT_OUTPUT_STREAM_PLUGIN = 'PRODUCT_IMPORT_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_IMPORT_ITERATOR_PLUGIN = 'PRODUCT_IMPORT_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_IMPORT_STAGE_PLUGINS = 'PRODUCT_IMPORT_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_IMPORT_PRE_PROCESSOR_PLUGINS = 'PRODUCT_IMPORT_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_IMPORT_POST_PROCESSOR_PLUGINS = 'PRODUCT_IMPORT_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_IMPORT_INPUT_STREAM_PLUGIN = 'PRODUCT_MODEL_IMPORT_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_IMPORT_OUTPUT_STREAM_PLUGIN = 'PRODUCT_MODEL_IMPORT_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_IMPORT_ITERATOR_PLUGIN = 'PRODUCT_MODEL_IMPORT_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_IMPORT_STAGE_PLUGINS = 'PRODUCT_MODEL_IMPORT_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_IMPORT_PRE_PROCESSOR_PLUGINS = 'PRODUCT_MODEL_IMPORT_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_IMPORT_POST_PROCESSOR_PLUGINS = 'PRODUCT_MODEL_IMPORT_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const PRODUCT_PREPARATION_INPUT_STREAM_PLUGIN = 'PRODUCT_PREPARATION_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_PREPARATION_OUTPUT_STREAM_PLUGIN = 'PRODUCT_PREPARATION_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_PREPARATION_ITERATOR_PLUGIN = 'PRODUCT_PREPARATION_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_PREPARATION_STAGE_PLUGINS = 'PRODUCT_PREPARATION_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_PREPARATION_PRE_PROCESSOR_PLUGINS = 'PRODUCT_PREPARATION_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_PREPARATION_POST_PROCESSOR_PLUGINS = 'PRODUCT_PREPARATION_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_PREPARATION_INPUT_STREAM_PLUGIN = 'PRODUCT_MODEL_PREPARATION_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_PREPARATION_OUTPUT_STREAM_PLUGIN = 'PRODUCT_MODEL_PREPARATION_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_PREPARATION_ITERATOR_PLUGIN = 'PRODUCT_MODEL_PREPARATION_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_PREPARATION_STAGE_PLUGINS = 'PRODUCT_MODEL_PREPARATION_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_PREPARATION_PRE_PROCESSOR_PLUGINS = 'PRODUCT_MODEL_PREPARATION_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const PRODUCT_MODEL_PREPARATION_POST_PROCESSOR_PLUGINS = 'PRODUCT_MODEL_PREPARATION_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const SUPER_ATTRIBUTE_IMPORT_INPUT_STREAM_PLUGIN = 'SUPER_ATTRIBUTE_IMPORT_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const SUPER_ATTRIBUTE_IMPORT_OUTPUT_STREAM_PLUGIN = 'SUPER_ATTRIBUTE_IMPORT_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const SUPER_ATTRIBUTE_IMPORT_ITERATOR_PLUGIN = 'SUPER_ATTRIBUTE_IMPORT_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const SUPER_ATTRIBUTE_IMPORT_STAGE_PLUGINS = 'SUPER_ATTRIBUTE_IMPORT_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const SUPER_ATTRIBUTE_IMPORT_PRE_PROCESSOR_PLUGINS = 'SUPER_ATTRIBUTE_IMPORT_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const SUPER_ATTRIBUTE_IMPORT_POST_PROCESSOR_PLUGINS = 'SUPER_ATTRIBUTE_IMPORT_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const TAX_SET_MAP_IMPORT_INPUT_STREAM_PLUGIN = 'TAX_SET_MAP_IMPORT_INPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const TAX_SET_MAP_IMPORT_OUTPUT_STREAM_PLUGIN = 'TAX_SET_MAP_IMPORT_OUTPUT_STREAM_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const TAX_SET_MAP_IMPORT_ITERATOR_PLUGIN = 'TAX_SET_MAP_IMPORT_ITERATOR_PLUGIN';
+
+    /**
+     * @var string
+     */
     public const TAX_SET_MAP_IMPORT_STAGE_PLUGINS = 'TAX_SET_MAP_IMPORT_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const TAX_SET_MAP_IMPORT_PRE_PROCESSOR_PLUGINS = 'TAX_SET_MAP_IMPORT_PRE_PROCESSOR_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const TAX_SET_MAP_IMPORT_POST_PROCESSOR_PLUGINS = 'TAX_SET_MAP_IMPORT_POST_PROCESSOR_PLUGINS';
 
+    /**
+     * @var string
+     */
     public const DEFAULT_CATEGORY_IMPORT_STAGE_PLUGINS = 'DEFAULT_CATEGORY_IMPORT_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const DEFAULT_PRODUCT_MODEL_IMPORT_STAGE_PLUGINS = 'DEFAULT_PRODUCT_MODEL_IMPORT_STAGE_PLUGINS';
+
+    /**
+     * @var string
+     */
     public const DEFAULT_PRODUCT_IMPORT_STAGE_PLUGINS = 'DEFAULT_PRODUCT_IMPORT_STAGE_PLUGINS';
 
     /**
@@ -311,7 +622,7 @@ class AkeneoPimMiddlewareConnectorDependencyProvider extends AbstractBundleDepen
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface>
      */
     protected function getAkeneoPimProcessesPlugins(): array
     {
@@ -344,7 +655,7 @@ class AkeneoPimMiddlewareConnectorDependencyProvider extends AbstractBundleDepen
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface>
      */
     protected function getDefaultAkeneoPimProcessesPlugins(): array
     {
@@ -783,7 +1094,7 @@ class AkeneoPimMiddlewareConnectorDependencyProvider extends AbstractBundleDepen
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface>
      */
     protected function getAkeneoPimTranslatorFunctionPlugins(): array
     {
@@ -812,7 +1123,7 @@ class AkeneoPimMiddlewareConnectorDependencyProvider extends AbstractBundleDepen
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Validator\GenericValidatorPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Validator\GenericValidatorPluginInterface>
      */
     protected function getAkeneoPimValidatorPlugins(): array
     {
@@ -836,7 +1147,7 @@ class AkeneoPimMiddlewareConnectorDependencyProvider extends AbstractBundleDepen
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface>
      */
     protected function getDefaultAkeneoPimTranslatorFunctionPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/AkeneoPimMiddlewareConnectorFacade.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/AkeneoPimMiddlewareConnectorFacade.php
@@ -18,7 +18,7 @@ use Spryker\Zed\Kernel\Business\AbstractFacade;
 class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements AkeneoPimMiddlewareConnectorFacadeInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -32,7 +32,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -46,7 +46,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -60,7 +60,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -74,7 +74,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -88,7 +88,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -102,7 +102,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -116,7 +116,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -130,7 +130,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -144,7 +144,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -160,7 +160,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -176,7 +176,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -190,7 +190,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -204,7 +204,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -218,7 +218,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -232,7 +232,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *
@@ -246,7 +246,7 @@ class AkeneoPimMiddlewareConnectorFacade extends AbstractFacade implements Akene
     }
 
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @api
      *

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Mapper/LocaleMapper.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Mapper/LocaleMapper.php
@@ -9,7 +9,14 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Mapper;
 
 class LocaleMapper implements LocaleMapperInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_COLUMN_LOCALE_NAME = 'spy_locale.locale_name';
+
+    /**
+     * @var string
+     */
     protected const KEY_COLUMN_LOCALE_ID = 'spy_locale.id_locale';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Mapper/Map/AttributeMapImportMap.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Mapper/Map/AttributeMapImportMap.php
@@ -12,6 +12,9 @@ use SprykerMiddleware\Zed\Process\Business\Mapper\Map\MapInterface;
 
 class AttributeMapImportMap extends AbstractMap
 {
+    /**
+     * @var array
+     */
     protected const ATTRIBUTE_MAP = [
         'pim_catalog_boolean' => 'number',
         'pim_catalog_textarea' => 'textarea',
@@ -27,6 +30,8 @@ class AttributeMapImportMap extends AbstractMap
         'pim_catalog_file' => 'text',
         'pim_catalog_date' => 'date',
         'pim_assets_collection' => 'text',
+        'pim_catalog_asset_collection' => 'text',
+        'akeneo_reference_entity' => 'text',
     ];
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Stream/Akeneo/SuperAttributeAkeneoApiReadStream.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Stream/Akeneo/SuperAttributeAkeneoApiReadStream.php
@@ -14,6 +14,9 @@ class SuperAttributeAkeneoApiReadStream extends AbstractAkeneoApiReadStream
      */
     protected $cursorVariants;
 
+    /**
+     * @var string
+     */
     protected const KEY_CODE = 'code';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Stream/DataImport/DataImportProductConcreteWriteStream.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Stream/DataImport/DataImportProductConcreteWriteStream.php
@@ -13,10 +13,29 @@ use SprykerMiddleware\Zed\Process\Business\Exception\MethodNotSupportedException
 
 class DataImportProductConcreteWriteStream implements WriteStreamInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_ABSTRACT_SKU = 'abstract_sku';
+
+    /**
+     * @var string
+     */
     protected const KEY_CONCRETE_SKU = 'concrete_sku';
+
+    /**
+     * @var string
+     */
     protected const KEY_PRICES = 'prices';
+
+    /**
+     * @var string
+     */
     protected const KEY_STORES = 'stores';
+
+    /**
+     * @var string
+     */
     protected const ABSTRACT_PRODUCT_CREATION_IDENTIFIER = 'abstract_product_creation';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/Dictionary/DefaultCategoryImportDictionary.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/Dictionary/DefaultCategoryImportDictionary.php
@@ -62,7 +62,7 @@ class DefaultCategoryImportDictionary extends AbstractDictionary
                 return $this->config->getFkCategoryTemplate();
             },
             'parent_category_key' => function ($value) {
-                if (empty($value)) {
+                if (!$value) {
                     return $this->config->getDefaultParentCategoryKey();
                 }
 

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/Generator/UrlGeneratorStrategy.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/Generator/UrlGeneratorStrategy.php
@@ -15,7 +15,7 @@ use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Dependency\Facade\AkeneoPimMiddl
 class UrlGeneratorStrategy implements UrlGeneratorStrategyInterface
 {
     /**
-     * @var int[] Keys are locale ids, values are locale names.
+     * @var array<int> Keys are locale ids, values are locale names.
      */
     protected static $idLocaleBuffer;
 

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddAbstractSkuIfNotExist.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddAbstractSkuIfNotExist.php
@@ -12,10 +12,29 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class AddAbstractSkuIfNotExist extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_PARENT = 'parent';
+
+    /**
+     * @var string
+     */
     protected const KEY_CODE = 'code';
+
+    /**
+     * @var string
+     */
     protected const KEY_IDENTIFIER = 'identifier';
+
+    /**
+     * @var string
+     */
     protected const KEY_ABSTRACT_SKU = 'abstract_sku';
+
+    /**
+     * @var string
+     */
     protected const ABSTRACT_IDENTIFIER = 'abstract_product_creation';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddAttributeOptions.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddAttributeOptions.php
@@ -14,6 +14,9 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class AddAttributeOptions extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var array
+     */
     protected const ATTRIBUTE_TYPES_WITH_OPTIONS = [
         'pim_catalog_simpleselect',
         'pim_catalog_multiselect',

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddAttributeValues.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddAttributeValues.php
@@ -12,8 +12,19 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class AddAttributeValues extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_OPTIONS = 'options';
+
+    /**
+     * @var string
+     */
     protected const KEY_VALUES = 'values';
+
+    /**
+     * @var string
+     */
     protected const KEY_VALUE_TRANSLATIONS = 'value_translations';
 
     /**
@@ -30,6 +41,7 @@ class AddAttributeValues extends AbstractTranslatorFunction implements Translato
             foreach ($payload[static::KEY_OPTIONS] as $optionKey => $optionValue) {
                 if (isset($optionValue[$inputValueKey])) {
                     $item[static::KEY_VALUE_TRANSLATIONS][$optionKey] = $optionValue[$inputValueKey];
+
                     continue;
                 }
                 $item[static::KEY_VALUE_TRANSLATIONS][$optionKey] = $optionKey;

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddFamilyAttribute.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddFamilyAttribute.php
@@ -12,6 +12,9 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class AddFamilyAttribute extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_FAMILY = 'family';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddMissingAttributes.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddMissingAttributes.php
@@ -12,6 +12,9 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class AddMissingAttributes extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_ATTRIBUTES = 'attributes';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddMissingLocales.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddMissingLocales.php
@@ -12,7 +12,14 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class AddMissingLocales extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const OPTION_LOCALES = 'locales';
+
+    /**
+     * @var string
+     */
     protected const KEY_LOCALIZED_ATTRIBUTES = 'localizedAttributes';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddUrlToLocalizedAttributes.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AddUrlToLocalizedAttributes.php
@@ -13,7 +13,14 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class AddUrlToLocalizedAttributes extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_NAME = 'name';
+
+    /**
+     * @var string
+     */
     protected const KEY_URL = 'url';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AttributeEmptyTranslationToKey.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/AttributeEmptyTranslationToKey.php
@@ -12,6 +12,9 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class AttributeEmptyTranslationToKey extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_CODE = 'code';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/DefaultPriceSelector.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/DefaultPriceSelector.php
@@ -13,17 +13,54 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class DefaultPriceSelector extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const DEFAULT_PRICE_TYPE = 'DEFAULT';
 
+    /**
+     * @var string
+     */
     protected const KEY_AMOUNT = 'amount';
+
+    /**
+     * @var string
+     */
     protected const KEY_DATA = 'data';
+
+    /**
+     * @var string
+     */
     protected const KEY_LOCALE = 'locale';
+
+    /**
+     * @var string
+     */
     protected const KEY_CURRENCY = 'currency';
+
+    /**
+     * @var string
+     */
     protected const KEY_PRICE = 'price';
+
+    /**
+     * @var string
+     */
     protected const KEY_PRICE_TYPE = 'type';
+
+    /**
+     * @var string
+     */
     protected const KEY_STORE = 'store';
 
+    /**
+     * @var string
+     */
     public const OPTION_STORES = 'OPTION_STORES';
+
+    /**
+     * @var string
+     */
     public const OPTION_LOCALE_TO_PRICE_MAP = 'LOCALE_TO_PRICE_MAP_OPTION';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/DefaultValuesToLocalizedAttributes.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/DefaultValuesToLocalizedAttributes.php
@@ -12,13 +12,34 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class DefaultValuesToLocalizedAttributes extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_LOCALIZED_ATTRIBUTES = 'localizedAttributes';
 
+    /**
+     * @var string
+     */
     protected const KEY_LOCALE = 'locale';
+
+    /**
+     * @var string
+     */
     protected const KEY_DATA = 'data';
 
+    /**
+     * @var string
+     */
     protected const KEY_ERP_NAME = 'erp_name';
+
+    /**
+     * @var string
+     */
     protected const KEY_NAME = 'name';
+
+    /**
+     * @var string
+     */
     protected const KEY_DESCRIPTION = 'description';
 
     /**
@@ -43,7 +64,7 @@ class DefaultValuesToLocalizedAttributes extends AbstractTranslatorFunction impl
                         $key,
                         $attribute[static::KEY_DATA],
                         $attribute[static::KEY_LOCALE],
-                        $localizedAttributes
+                        $localizedAttributes,
                     );
                 }
 
@@ -53,7 +74,7 @@ class DefaultValuesToLocalizedAttributes extends AbstractTranslatorFunction impl
                             $key,
                             $localizedValue,
                             $locale,
-                            $localizedAttributes
+                            $localizedAttributes,
                         );
                     }
                 }

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/EnrichAttributes.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/EnrichAttributes.php
@@ -12,20 +12,52 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class EnrichAttributes extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_OPTIONS = 'options';
+
+    /**
+     * @var string
+     */
     protected const KEY_DATA = 'data';
+
+    /**
+     * @var string
+     */
     protected const KEY_LOCALE = 'locale';
+
+    /**
+     * @var string
+     */
     protected const KEY_TYPE = 'type';
+
+    /**
+     * @var string
+     */
     protected const KEY_LOCALIZABLE = 'localizable';
+
+    /**
+     * @var string
+     */
     protected const KEY_KEY = 'key';
 
+    /**
+     * @var string
+     */
     protected const ATTRIBUTE_PRICE = 'price';
 
+    /**
+     * @var array
+     */
     protected const ATTRIBUTE_TYPES_WITH_OPTIONS = [
         'pim_catalog_simpleselect',
         'pim_catalog_multiselect',
     ];
 
+    /**
+     * @var array
+     */
     protected const ATTRIBUTES_TYPES_FOR_SKIPPING = [
         'pim_assets_collection',
         'pim_reference_data_multiselect',
@@ -68,6 +100,7 @@ class EnrichAttributes extends AbstractTranslatorFunction implements TranslatorF
         foreach ($value as $attributeKey => $attributeValues) {
             if ($this->isKeySkipped($attributeKey)) {
                 unset($value[$attributeKey]);
+
                 continue;
             }
 
@@ -83,6 +116,7 @@ class EnrichAttributes extends AbstractTranslatorFunction implements TranslatorF
 
                 if ($attributeData === null) {
                     unset($value[$attributeKey]);
+
                     continue 2;
                 }
 
@@ -90,10 +124,12 @@ class EnrichAttributes extends AbstractTranslatorFunction implements TranslatorF
                     $options = is_array($attributeData) ? $this->getArrayOptions($attributeKey, $attributeData) : $this->getOptions($attributeKey, $attributeData);
                     if (!array_key_exists($locale, $options)) {
                         unset($value[$attributeKey]);
+
                         continue;
                     }
 
                     $value[$attributeKey][$index][static::KEY_DATA] = $options[$locale];
+
                     continue;
                 }
 
@@ -128,7 +164,7 @@ class EnrichAttributes extends AbstractTranslatorFunction implements TranslatorF
             array_filter($this->getMap(), function ($element) {
                 return count($element[static::KEY_OPTIONS] ?? []) > 0 &&
                     in_array($element[static::KEY_TYPE], static::ATTRIBUTE_TYPES_WITH_OPTIONS);
-            })
+            }),
         );
 
         static::$attributeLocalizableMap = array_map(
@@ -137,7 +173,7 @@ class EnrichAttributes extends AbstractTranslatorFunction implements TranslatorF
             },
             array_filter($this->getMap(), function ($element) {
                 return in_array($element[static::KEY_TYPE], static::ATTRIBUTE_TYPES_WITH_OPTIONS);
-            })
+            }),
         );
 
         static::$attributesForSkippingMap = array_map(
@@ -146,7 +182,7 @@ class EnrichAttributes extends AbstractTranslatorFunction implements TranslatorF
             },
             array_filter($this->getMap(), function ($element) {
                 return in_array($element[static::KEY_TYPE], static::ATTRIBUTES_TYPES_FOR_SKIPPING) && $element[static::KEY_KEY] != static::ATTRIBUTE_PRICE;
-            })
+            }),
         );
     }
 

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/LabelsToLocaleIds.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/LabelsToLocaleIds.php
@@ -31,7 +31,7 @@ class LabelsToLocaleIds extends AbstractTranslatorFunction implements Translator
             return $value;
         }
 
-        if (empty($value)) {
+        if (!$value) {
             $value = $this->getMap();
         }
 

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/LabelsToLocalizedAttributeNames.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/LabelsToLocalizedAttributeNames.php
@@ -12,6 +12,9 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class LabelsToLocalizedAttributeNames extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_NAME = 'name';
 
     /**
@@ -24,9 +27,9 @@ class LabelsToLocalizedAttributeNames extends AbstractTranslatorFunction impleme
     {
         $defaultLocales = $this->getLocales();
 
-        $key = isset($this->options['key']) ? $this->options['key'] : static::KEY_NAME;
+        $key = $this->options['key'] ?? static::KEY_NAME;
 
-        if (empty($value) && $defaultLocales) {
+        if (!$value && $defaultLocales) {
             $code = $payload['category_key'];
             foreach ($defaultLocales as $locale) {
                 $value[$locale] = [

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/MeasureUnitToInt.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/MeasureUnitToInt.php
@@ -12,7 +12,14 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class MeasureUnitToInt extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_DATA = 'data';
+
+    /**
+     * @var string
+     */
     protected const KEY_AMOUNT = 'amount';
 
     /**

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/MoveLocalizedAttributesToAttributes.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/MoveLocalizedAttributesToAttributes.php
@@ -12,7 +12,14 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class MoveLocalizedAttributesToAttributes extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     public const KEY_ATTRIBUTES = 'attributes';
+
+    /**
+     * @var string
+     */
     public const ATTRIBUTE_BLACKLIST = 'blacklist';
 
     /**
@@ -30,7 +37,6 @@ class MoveLocalizedAttributesToAttributes extends AbstractTranslatorFunction imp
      */
     public function translate($value, array $payload): array
     {
-
         foreach ($value as $localeId => $scopedAttributes) {
             if (!isset($value[$localeId][static::KEY_ATTRIBUTES])) {
                 $value[$localeId][static::KEY_ATTRIBUTES] = [];

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/PriceSelector.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/PriceSelector.php
@@ -13,15 +13,44 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class PriceSelector extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_LOCALE = 'locale';
+
+    /**
+     * @var string
+     */
     protected const KEY_DATA = 'data';
+
+    /**
+     * @var string
+     */
     protected const KEY_AMOUNT = 'amount';
 
+    /**
+     * @var string
+     */
     protected const KEY_PRICE = 'price';
+
+    /**
+     * @var string
+     */
     protected const KEY_CURRENCY = 'currency';
+
+    /**
+     * @var string
+     */
     protected const KEY_PRICE_TYPE = 'type';
+
+    /**
+     * @var string
+     */
     protected const KEY_STORE = 'store';
 
+    /**
+     * @var string
+     */
     public const OPTION_LOCALE_TO_PRICE_MAP = 'LOCALE_TO_PRICE_MAP_OPTION';
 
     /**
@@ -56,8 +85,8 @@ class PriceSelector extends AbstractTranslatorFunction implements TranslatorFunc
             }
 
             $currency = $localeToPriceTypeMap[$locale][static::KEY_CURRENCY] ?? null;
-            $type = $localeToPriceTypeMap[$locale][self::KEY_PRICE_TYPE] ?? null;
-            $store = $localeToPriceTypeMap[$locale][self::KEY_STORE] ?? null;
+            $type = $localeToPriceTypeMap[$locale][static::KEY_PRICE_TYPE] ?? null;
+            $store = $localeToPriceTypeMap[$locale][static::KEY_STORE] ?? null;
 
             foreach ($priceInfo[static::KEY_DATA] as $price) {
                 if ($price[static::KEY_CURRENCY] === $currency) {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/SkipItemsWithoutParent.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/SkipItemsWithoutParent.php
@@ -22,7 +22,7 @@ class SkipItemsWithoutParent extends AbstractTranslatorFunction
      */
     public function translate($value, array $payload)
     {
-        if (empty($value)) {
+        if (!$value) {
             throw new MissingParentForProductException();
         }
 

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/ValuesToAttributes.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/ValuesToAttributes.php
@@ -12,9 +12,19 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class ValuesToAttributes extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_ATTRIBUTES = 'attributes';
 
+    /**
+     * @var string
+     */
     protected const KEY_LOCALE = 'locale';
+
+    /**
+     * @var string
+     */
     protected const KEY_DATA = 'data';
 
     /**
@@ -35,7 +45,7 @@ class ValuesToAttributes extends AbstractTranslatorFunction implements Translato
         foreach ($value as $key => $scopedAttributes) {
             foreach ($scopedAttributes as $attribute) {
                 if (!$this->isLocalizedAttribute($attribute)) {
-                    $value[static::KEY_ATTRIBUTES][$key] = $attribute[static::KEY_DATA];
+                    $value[static::KEY_ATTRIBUTES][$key] = $attribute[static::KEY_DATA] ?? null;
                 }
             }
         }

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/ValuesToLocalizedAttributes.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Translator/TranslatorFunction/ValuesToLocalizedAttributes.php
@@ -12,13 +12,34 @@ use SprykerMiddleware\Zed\Process\Business\Translator\TranslatorFunction\Transla
 
 class ValuesToLocalizedAttributes extends AbstractTranslatorFunction implements TranslatorFunctionInterface
 {
+    /**
+     * @var string
+     */
     protected const KEY_LOCALIZED_ATTRIBUTES = 'localizedAttributes';
 
+    /**
+     * @var string
+     */
     protected const KEY_LOCALE = 'locale';
+
+    /**
+     * @var string
+     */
     protected const KEY_DATA = 'data';
 
+    /**
+     * @var string
+     */
     protected const KEY_TITLE = 'title';
+
+    /**
+     * @var string
+     */
     protected const KEY_NAME = 'name';
+
+    /**
+     * @var string
+     */
     protected const KEY_DESCRIPTION = 'description';
 
     /**
@@ -43,7 +64,7 @@ class ValuesToLocalizedAttributes extends AbstractTranslatorFunction implements 
                         $key,
                         $attribute[static::KEY_DATA],
                         $attribute[static::KEY_LOCALE],
-                        $localizedAttributes
+                        $localizedAttributes,
                     );
                 }
 
@@ -53,7 +74,7 @@ class ValuesToLocalizedAttributes extends AbstractTranslatorFunction implements 
                             $key,
                             $localizedValue,
                             $locale,
-                            $localizedAttributes
+                            $localizedAttributes,
                         );
                     }
                 }

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Validator/ValidationRuleSet/ProductImportValidationRuleSet.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Business/Validator/ValidationRuleSet/ProductImportValidationRuleSet.php
@@ -14,7 +14,7 @@ use SprykerMiddleware\Zed\Process\Business\Validator\ValidationRuleSet\Validatio
 class ProductImportValidationRuleSet extends AbstractValidationRuleSet implements ValidationRuleSetInterface
 {
     /**
-     * @var string[]
+     * @var array<string>
      */
     protected static $skuValues;
 

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/AkeneoPimMiddlewareConnectorCommunicationFactory.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/AkeneoPimMiddlewareConnectorCommunicationFactory.php
@@ -62,12 +62,12 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
             $this->getProductAbstractImporterPlugin(),
             $this->getProductConcreteImporterPlugin(),
             $this->getProductPriceImporterPlugin(),
-            $this->getProductAbstractStoresImporterPlugin()
+            $this->getProductAbstractStoresImporterPlugin(),
         );
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface>
      */
     public function getAkeneoPimProcesses(): array
     {
@@ -75,7 +75,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface>
      */
     public function getAkeneoPimTranslatorFunctions(): array
     {
@@ -83,7 +83,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Validator\GenericValidatorPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Validator\GenericValidatorPluginInterface>
      */
     public function getAkeneoPimValidators(): array
     {
@@ -139,7 +139,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getProductImportPreProcessorPluginsStack(): array
     {
@@ -147,7 +147,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getProductImportStagePluginsStack(): array
     {
@@ -155,7 +155,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getProductImportPostProcessorPluginsStack(): array
     {
@@ -187,7 +187,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getAttributeImportPreProcessorPluginsStack(): array
     {
@@ -195,7 +195,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getAttributeImportStagePluginsStack(): array
     {
@@ -203,7 +203,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getAttributeImportPostProcessorPluginsStack(): array
     {
@@ -235,7 +235,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getAttributeMapPreProcessorPluginsStack(): array
     {
@@ -243,7 +243,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getAttributeMapStagePluginsStack(): array
     {
@@ -251,7 +251,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getAttributeMapPostProcessorPluginsStack(): array
     {
@@ -283,7 +283,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getCategoryImportPreProcessorPluginsStack(): array
     {
@@ -291,7 +291,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getCategoryImportStagePluginsStack(): array
     {
@@ -299,7 +299,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getCategoryImportPostProcessorPluginsStack(): array
     {
@@ -331,7 +331,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getLocaleMapPreProcessorPluginsStack(): array
     {
@@ -339,7 +339,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getLocaleMapStagePluginsStack(): array
     {
@@ -347,7 +347,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getLocaleMapPostProcessorPluginsStack(): array
     {
@@ -379,7 +379,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getProductModelImportPreProcessorPluginsStack(): array
     {
@@ -387,7 +387,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getProductModelImportStagePluginsStack(): array
     {
@@ -395,7 +395,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getProductModelImportPostProcessorPluginsStack(): array
     {
@@ -427,7 +427,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getProductModelPreparationPreProcessorPluginsStack(): array
     {
@@ -435,7 +435,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getProductModelPreparationStagePluginsStack(): array
     {
@@ -443,7 +443,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getProductModelPreparationPostProcessorPluginsStack(): array
     {
@@ -499,7 +499,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getProductPreparationPreProcessorPluginsStack(): array
     {
@@ -507,7 +507,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getSuperAttributesImportPreProcessorPluginsStack(): array
     {
@@ -515,7 +515,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getProductPreparationStagePluginsStack(): array
     {
@@ -523,7 +523,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getSuperAttributesImportStagePluginsStack(): array
     {
@@ -531,7 +531,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getProductPreparationPostProcessorPluginsStack(): array
     {
@@ -539,7 +539,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getSuperAttributesImportPostProcessorPluginsStack(): array
     {
@@ -571,7 +571,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>>
      */
     public function getTaxSetMapImportPreProcessorPluginsStack(): array
     {
@@ -579,7 +579,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getTaxSetMapImportStagePluginsStack(): array
     {
@@ -587,7 +587,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[][]
+     * @return array<array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>>
      */
     public function getTaxSetMapImportPostProcessorPluginsStack(): array
     {
@@ -635,7 +635,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface>
      */
     public function getDefaultAkeneoPimProcesses()
     {
@@ -643,7 +643,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface>
      */
     public function getDefaultAkeneoPimTranslatorFunctions()
     {
@@ -651,7 +651,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getDefaultCategoryImportStagePluginsStack(): array
     {
@@ -659,7 +659,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getDefaultProductImportStagePluginsStack(): array
     {
@@ -667,7 +667,7 @@ class AkeneoPimMiddlewareConnectorCommunicationFactory extends AbstractCommunica
     }
 
     /**
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getDefaultProductModelImportStagePluginsStack(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/AttributeMapMapperStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/AttributeMapMapperStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class AttributeMapMapperStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'AttributeMapMapperStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class AttributeMapMapperStagePlugin extends AbstractPlugin implements StagePlugi
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class AttributeMapMapperStagePlugin extends AbstractPlugin implements StagePlugi
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/AttributeMapPreparationMapperStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/AttributeMapPreparationMapperStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class AttributeMapPreparationMapperStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'AttributeMapPreparationMapperStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class AttributeMapPreparationMapperStagePlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class AttributeMapPreparationMapperStagePlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/AttributeMapTranslationStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/AttributeMapTranslationStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class AttributeMapTranslationStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'AttributeMapTranslationStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class AttributeMapTranslationStagePlugin extends AbstractPlugin implements Stage
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class AttributeMapTranslationStagePlugin extends AbstractPlugin implements Stage
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/CategoryImportTranslationStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/CategoryImportTranslationStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class CategoryImportTranslationStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'CategoryImportTranslationStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class CategoryImportTranslationStagePlugin extends AbstractPlugin implements Sta
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class CategoryImportTranslationStagePlugin extends AbstractPlugin implements Sta
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/CategoryMapperStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/CategoryMapperStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class CategoryMapperStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'CategoryMapperStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class CategoryMapperStagePlugin extends AbstractPlugin implements StagePluginInt
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class CategoryMapperStagePlugin extends AbstractPlugin implements StagePluginInt
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/AkeneoPimConfigurationProfilePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/AkeneoPimConfigurationProfilePlugin.php
@@ -19,9 +19,11 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ConfigurationP
 class AkeneoPimConfigurationProfilePlugin extends AbstractPlugin implements ConfigurationProfilePluginInterface
 {
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface>
      */
     public function getProcessConfigurationPlugins(): array
     {
@@ -30,9 +32,11 @@ class AkeneoPimConfigurationProfilePlugin extends AbstractPlugin implements Conf
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface>
      */
     public function getTranslatorFunctionPlugins(): array
     {
@@ -41,9 +45,11 @@ class AkeneoPimConfigurationProfilePlugin extends AbstractPlugin implements Conf
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Validator\ValidatorPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Validator\ValidatorPluginInterface>
      */
     public function getValidatorPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/AttributeImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/AttributeImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class AttributeImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'ATTRIBUTE_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class AttributeImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class AttributeImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class AttributeImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class AttributeImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class AttributeImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class AttributeImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class AttributeImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/AttributeMapConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/AttributeMapConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class AttributeMapConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'ATTRIBUTE_MAP_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class AttributeMapConfigurationPlugin extends AbstractPlugin implements ProcessC
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class AttributeMapConfigurationPlugin extends AbstractPlugin implements ProcessC
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class AttributeMapConfigurationPlugin extends AbstractPlugin implements ProcessC
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class AttributeMapConfigurationPlugin extends AbstractPlugin implements ProcessC
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class AttributeMapConfigurationPlugin extends AbstractPlugin implements ProcessC
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class AttributeMapConfigurationPlugin extends AbstractPlugin implements ProcessC
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class AttributeMapConfigurationPlugin extends AbstractPlugin implements ProcessC
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/CategoryImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/CategoryImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class CategoryImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'CATEGORY_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class CategoryImportConfigurationPlugin extends AbstractPlugin implements Proces
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class CategoryImportConfigurationPlugin extends AbstractPlugin implements Proces
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class CategoryImportConfigurationPlugin extends AbstractPlugin implements Proces
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class CategoryImportConfigurationPlugin extends AbstractPlugin implements Proces
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class CategoryImportConfigurationPlugin extends AbstractPlugin implements Proces
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class CategoryImportConfigurationPlugin extends AbstractPlugin implements Proces
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class CategoryImportConfigurationPlugin extends AbstractPlugin implements Proces
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultAkeneoPimConfigurationProfilePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultAkeneoPimConfigurationProfilePlugin.php
@@ -19,9 +19,11 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ConfigurationP
 class DefaultAkeneoPimConfigurationProfilePlugin extends AbstractPlugin implements ConfigurationProfilePluginInterface
 {
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Configuration\ProcessConfigurationPluginInterface>
      */
     public function getProcessConfigurationPlugins(): array
     {
@@ -30,9 +32,11 @@ class DefaultAkeneoPimConfigurationProfilePlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\TranslatorFunctionPluginInterface>
      */
     public function getTranslatorFunctionPlugins(): array
     {
@@ -41,9 +45,11 @@ class DefaultAkeneoPimConfigurationProfilePlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Validator\ValidatorPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Validator\ValidatorPluginInterface>
      */
     public function getValidatorPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultCategoryImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultCategoryImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class DefaultCategoryImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'DEFAULT_CATEGORY_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class DefaultCategoryImportConfigurationPlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class DefaultCategoryImportConfigurationPlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class DefaultCategoryImportConfigurationPlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class DefaultCategoryImportConfigurationPlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class DefaultCategoryImportConfigurationPlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class DefaultCategoryImportConfigurationPlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class DefaultCategoryImportConfigurationPlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultProductImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultProductImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class DefaultProductImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'DEFAULT_PRODUCT_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class DefaultProductImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class DefaultProductImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class DefaultProductImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class DefaultProductImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class DefaultProductImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class DefaultProductImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class DefaultProductImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultProductModelImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/DefaultProductModelImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class DefaultProductModelImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'DEFAULT_PRODUCT_MODEL_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class DefaultProductModelImportConfigurationPlugin extends AbstractPlugin implem
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class DefaultProductModelImportConfigurationPlugin extends AbstractPlugin implem
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class DefaultProductModelImportConfigurationPlugin extends AbstractPlugin implem
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class DefaultProductModelImportConfigurationPlugin extends AbstractPlugin implem
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class DefaultProductModelImportConfigurationPlugin extends AbstractPlugin implem
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class DefaultProductModelImportConfigurationPlugin extends AbstractPlugin implem
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class DefaultProductModelImportConfigurationPlugin extends AbstractPlugin implem
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/LocaleMapImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/LocaleMapImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class LocaleMapImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'LOCALE_MAP_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class LocaleMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class LocaleMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class LocaleMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class LocaleMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class LocaleMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class LocaleMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class LocaleMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/ProductImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/ProductImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class ProductImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'PRODUCT_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class ProductImportConfigurationPlugin extends AbstractPlugin implements Process
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class ProductImportConfigurationPlugin extends AbstractPlugin implements Process
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class ProductImportConfigurationPlugin extends AbstractPlugin implements Process
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class ProductImportConfigurationPlugin extends AbstractPlugin implements Process
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class ProductImportConfigurationPlugin extends AbstractPlugin implements Process
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class ProductImportConfigurationPlugin extends AbstractPlugin implements Process
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class ProductImportConfigurationPlugin extends AbstractPlugin implements Process
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/ProductModelImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/ProductModelImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class ProductModelImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'PRODUCT_MODEL_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class ProductModelImportConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class ProductModelImportConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class ProductModelImportConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class ProductModelImportConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class ProductModelImportConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class ProductModelImportConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class ProductModelImportConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/ProductModelPreparationConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/ProductModelPreparationConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class ProductModelPreparationConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'PRODUCT_MODEL_PREPARATION_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class ProductModelPreparationConfigurationPlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class ProductModelPreparationConfigurationPlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class ProductModelPreparationConfigurationPlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class ProductModelPreparationConfigurationPlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class ProductModelPreparationConfigurationPlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class ProductModelPreparationConfigurationPlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class ProductModelPreparationConfigurationPlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/ProductPreparationConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/ProductPreparationConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class ProductPreparationConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'PRODUCT_PREPARATION_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class ProductPreparationConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class ProductPreparationConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class ProductPreparationConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class ProductPreparationConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class ProductPreparationConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -89,9 +104,11 @@ class ProductPreparationConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -100,9 +117,11 @@ class ProductPreparationConfigurationPlugin extends AbstractPlugin implements Pr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/SuperAttributeImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/SuperAttributeImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class SuperAttributeImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'SUPER_ATTRIBUTE_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class SuperAttributeImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class SuperAttributeImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class SuperAttributeImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class SuperAttributeImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class SuperAttributeImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class SuperAttributeImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class SuperAttributeImportConfigurationPlugin extends AbstractPlugin implements 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/TaxSetMapImportConfigurationPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Configuration/TaxSetMapImportConfigurationPlugin.php
@@ -22,9 +22,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class TaxSetMapImportConfigurationPlugin extends AbstractPlugin implements ProcessConfigurationPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PROCESS_NAME = 'TAX_SET_MAP_IMPORT_PROCESS';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -35,6 +40,8 @@ class TaxSetMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInterface
@@ -46,6 +53,8 @@ class TaxSetMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInterface
@@ -57,6 +66,8 @@ class TaxSetMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Iterator\ProcessIteratorPluginInterface
@@ -68,9 +79,11 @@ class TaxSetMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface>
      */
     public function getStagePlugins(): array
     {
@@ -79,6 +92,8 @@ class TaxSetMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Log\MiddlewareLoggerConfigPluginInterface
@@ -90,9 +105,11 @@ class TaxSetMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PreProcessorHookPluginInterface>
      */
     public function getPreProcessorHookPlugins(): array
     {
@@ -101,9 +118,11 @@ class TaxSetMapImportConfigurationPlugin extends AbstractPlugin implements Proce
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
-     * @return \SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface[]
+     * @return array<\SprykerMiddleware\Zed\Process\Dependency\Plugin\Hook\PostProcessorHookPluginInterface>
      */
     public function getPostProcessorHookPlugins(): array
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultCategoryImportTranslationStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultCategoryImportTranslationStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class DefaultCategoryImportTranslationStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'DefaultCategoryImportTranslationStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class DefaultCategoryImportTranslationStagePlugin extends AbstractPlugin impleme
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class DefaultCategoryImportTranslationStagePlugin extends AbstractPlugin impleme
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultCategoryMapperStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultCategoryMapperStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class DefaultCategoryMapperStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'DefaultCategoryMapperStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class DefaultCategoryMapperStagePlugin extends AbstractPlugin implements StagePl
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class DefaultCategoryMapperStagePlugin extends AbstractPlugin implements StagePl
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultProductImportTranslationStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultProductImportTranslationStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class DefaultProductImportTranslationStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'DefaultProductImportTranslationStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class DefaultProductImportTranslationStagePlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param array $payload
@@ -48,6 +53,8 @@ class DefaultProductImportTranslationStagePlugin extends AbstractPlugin implemen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultProductImportValidatorStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultProductImportValidatorStagePlugin.php
@@ -20,9 +20,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class DefaultProductImportValidatorStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'DefaultProductImportValidatorStagePlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -33,13 +38,15 @@ class DefaultProductImportValidatorStagePlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
      * @param \SprykerMiddleware\Shared\Process\Stream\WriteStreamInterface $outStream
      * @param mixed $originalPayload
      *
-     * @return array|mixed
+     * @return mixed|array
      */
     public function process($payload, WriteStreamInterface $outStream, $originalPayload)
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultProductModelImportTranslationStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultProductModelImportTranslationStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class DefaultProductModelImportTranslationStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'DefaultProductModelImportTranslationStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class DefaultProductModelImportTranslationStagePlugin extends AbstractPlugin imp
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class DefaultProductModelImportTranslationStagePlugin extends AbstractPlugin imp
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultProductModelImportValidatorStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/DefaultProductModelImportValidatorStagePlugin.php
@@ -20,9 +20,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class DefaultProductModelImportValidatorStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'DefaultProductModelImportValidatorStagePlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -33,13 +38,15 @@ class DefaultProductModelImportValidatorStagePlugin extends AbstractPlugin imple
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
      * @param \SprykerMiddleware\Shared\Process\Stream\WriteStreamInterface $outStream
      * @param mixed $originalPayload
      *
-     * @return array|mixed
+     * @return mixed|array
      */
     public function process($payload, WriteStreamInterface $outStream, $originalPayload)
     {

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/LocaleMapperStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/LocaleMapperStagePlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class LocaleMapperStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'LocaleMapperStagePlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -37,6 +42,8 @@ class LocaleMapperStagePlugin extends AbstractPlugin implements StagePluginInter
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/ProductImportTranslationStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/ProductImportTranslationStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class ProductImportTranslationStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'ProductImportTranslationStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class ProductImportTranslationStagePlugin extends AbstractPlugin implements Stag
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class ProductImportTranslationStagePlugin extends AbstractPlugin implements Stag
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/ProductMapperStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/ProductMapperStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class ProductMapperStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'ProductMapperStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class ProductMapperStagePlugin extends AbstractPlugin implements StagePluginInte
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class ProductMapperStagePlugin extends AbstractPlugin implements StagePluginInte
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/ProductModelImportMapperStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/ProductModelImportMapperStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class ProductModelImportMapperStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'ProductModelImportMapperStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class ProductModelImportMapperStagePlugin extends AbstractPlugin implements Stag
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class ProductModelImportMapperStagePlugin extends AbstractPlugin implements Stag
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/ProductModelImportTranslationStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/ProductModelImportTranslationStagePlugin.php
@@ -20,6 +20,9 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class ProductModelImportTranslationStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'ProductModelImportTranslationStagePlugin';
 
     /**
@@ -32,6 +35,8 @@ class ProductModelImportTranslationStagePlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -48,6 +53,8 @@ class ProductModelImportTranslationStagePlugin extends AbstractPlugin implements
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/AttributeAkeneoApiStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/AttributeAkeneoApiStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInte
  */
 class AttributeAkeneoApiStreamPlugin extends AbstractPlugin implements InputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'AttributeAkeneoApiStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class AttributeAkeneoApiStreamPlugin extends AbstractPlugin implements InputStre
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/AttributeWriteStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/AttributeWriteStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class AttributeWriteStreamPlugin extends AbstractPlugin implements OutputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'AttributeWriteStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class AttributeWriteStreamPlugin extends AbstractPlugin implements OutputStreamP
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/CategoryAkeneoApiStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/CategoryAkeneoApiStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInte
  */
 class CategoryAkeneoApiStreamPlugin extends AbstractPlugin implements InputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'CategoryAkeneoApiStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class CategoryAkeneoApiStreamPlugin extends AbstractPlugin implements InputStrea
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/CategoryWriteStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/CategoryWriteStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class CategoryWriteStreamPlugin extends AbstractPlugin implements OutputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'CategoryWriteStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class CategoryWriteStreamPlugin extends AbstractPlugin implements OutputStreamPl
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/JsonObjectWriteStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/JsonObjectWriteStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class JsonObjectWriteStreamPlugin extends AbstractPlugin implements OutputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'JsonObjectWriteStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class JsonObjectWriteStreamPlugin extends AbstractPlugin implements OutputStream
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/JsonSuperAttributeWriteStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/JsonSuperAttributeWriteStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class JsonSuperAttributeWriteStreamPlugin extends AbstractPlugin implements OutputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'JsonSuperAttributeWriteStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class JsonSuperAttributeWriteStreamPlugin extends AbstractPlugin implements Outp
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/LocaleStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/LocaleStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInte
  */
 class LocaleStreamPlugin extends AbstractPlugin implements InputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'LocaleStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class LocaleStreamPlugin extends AbstractPlugin implements InputStreamPluginInte
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/ProductAbstractWriteStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/ProductAbstractWriteStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class ProductAbstractWriteStreamPlugin extends AbstractPlugin implements OutputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'ProductAbstractWriteStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class ProductAbstractWriteStreamPlugin extends AbstractPlugin implements OutputS
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/ProductAkeneoApiStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/ProductAkeneoApiStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInte
  */
 class ProductAkeneoApiStreamPlugin extends AbstractPlugin implements InputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'ProductAkeneoApiStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class ProductAkeneoApiStreamPlugin extends AbstractPlugin implements InputStream
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/ProductConcreteWriteStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/ProductConcreteWriteStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\OutputStreamPluginInt
  */
 class ProductConcreteWriteStreamPlugin extends AbstractPlugin implements OutputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'ProductConcreteWriteStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class ProductConcreteWriteStreamPlugin extends AbstractPlugin implements OutputS
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/ProductModelAkeneoApiStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/ProductModelAkeneoApiStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInte
  */
 class ProductModelAkeneoApiStreamPlugin extends AbstractPlugin implements InputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'ProductModelAkeneoApiStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class ProductModelAkeneoApiStreamPlugin extends AbstractPlugin implements InputS
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/SuperAttributesAkeneoApiStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/SuperAttributesAkeneoApiStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInte
  */
 class SuperAttributesAkeneoApiStreamPlugin extends AbstractPlugin implements InputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'SuperAttributesAkeneoApiStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class SuperAttributesAkeneoApiStreamPlugin extends AbstractPlugin implements Inp
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/TaxSetStreamPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Stream/TaxSetStreamPlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\Stream\InputStreamPluginInte
  */
 class TaxSetStreamPlugin extends AbstractPlugin implements InputStreamPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'TaxSetStreamPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param string $path
@@ -36,6 +41,8 @@ class TaxSetStreamPlugin extends AbstractPlugin implements InputStreamPluginInte
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TaxSetMapperStagePlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TaxSetMapperStagePlugin.php
@@ -19,9 +19,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\StagePluginInterface;
  */
 class TaxSetMapperStagePlugin extends AbstractPlugin implements StagePluginInterface
 {
+    /**
+     * @var string
+     */
     protected const PLUGIN_NAME = 'TaxSetMapperStagePlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $payload
@@ -37,6 +42,8 @@ class TaxSetMapperStagePlugin extends AbstractPlugin implements StagePluginInter
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddAbstractSkuIfNotExistTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddAbstractSkuIfNotExistTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\AddAbstractSkuIfNotExist;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class AddAbstractSkuIfNotExistTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'AddAbstractSkuIfNotExist';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class AddAbstractSkuIfNotExistTranslatorFunctionPlugin extends AbstractGenericTr
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddAttributeOptionsTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddAttributeOptionsTranslatorFunctionPlugin.php
@@ -18,9 +18,14 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\Translato
  */
 class AddAttributeOptionsTranslatorFunctionPlugin extends AbstractPlugin implements TranslatorFunctionPluginInterface
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'AddAttributeOptions';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -31,6 +36,8 @@ class AddAttributeOptionsTranslatorFunctionPlugin extends AbstractPlugin impleme
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $value

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddAttributeValuesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddAttributeValuesTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\AddAttributeValues;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class AddAttributeValuesTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'AddAttributeValues';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class AddAttributeValuesTranslatorFunctionPlugin extends AbstractGenericTranslat
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddFamilyAttributeTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddFamilyAttributeTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\AddFamilyAttribute;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class AddFamilyAttributeTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'AddFamilyAttribute';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class AddFamilyAttributeTranslatorFunctionPlugin extends AbstractGenericTranslat
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddMissingAttributesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddMissingAttributesTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\AddMissingAttributes;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class AddMissingAttributesTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'AddMissingAttributes';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class AddMissingAttributesTranslatorFunctionPlugin extends AbstractGenericTransl
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddMissingLocalesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddMissingLocalesTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\AddMissingLocales;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class AddMissingLocalesTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'AddMissingLocales';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class AddMissingLocalesTranslatorFunctionPlugin extends AbstractGenericTranslato
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddUrlToLocalizedAttributesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AddUrlToLocalizedAttributesTranslatorFunctionPlugin.php
@@ -18,12 +18,24 @@ use SprykerMiddleware\Zed\Process\Dependency\Plugin\TranslatorFunction\Translato
  */
 class AddUrlToLocalizedAttributesTranslatorFunctionPlugin extends AbstractPlugin implements TranslatorFunctionPluginInterface
 {
+    /**
+     * @var string
+     */
     public const NAME = 'AddUrlToLocalizedAttributes';
 
+    /**
+     * @var string
+     */
     public const KEY_NAME = 'name';
+
+    /**
+     * @var string
+     */
     public const KEY_URL = 'url';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -34,6 +46,8 @@ class AddUrlToLocalizedAttributesTranslatorFunctionPlugin extends AbstractPlugin
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $value

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AttributeEmptyTranslationToKeyTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/AttributeEmptyTranslationToKeyTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\AttributeEmptyTranslationToKey;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class AttributeEmptyTranslationToKeyTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'AttributeEmptyTranslationToKey';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class AttributeEmptyTranslationToKeyTranslatorFunctionPlugin extends AbstractGen
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/DefaultPriceSelectorTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/DefaultPriceSelectorTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\DefaultPriceSelector;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class DefaultPriceSelectorTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'DefaultPriceSelector';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class DefaultPriceSelectorTranslatorFunctionPlugin extends AbstractGenericTransl
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/DefaultValuesToLocalizedAttributesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/DefaultValuesToLocalizedAttributesTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\DefaultValuesToLocalizedAttributes;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class DefaultValuesToLocalizedAttributesTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'DefaultValuesToLocalizedAttributes';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class DefaultValuesToLocalizedAttributesTranslatorFunctionPlugin extends Abstrac
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/EnrichAttributesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/EnrichAttributesTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\EnrichAttributes;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class EnrichAttributesTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'EnrichAttributes';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class EnrichAttributesTranslatorFunctionPlugin extends AbstractGenericTranslator
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/LabelsToLocaleIdsTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/LabelsToLocaleIdsTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\LabelsToLocaleIds;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class LabelsToLocaleIdsTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'LabelsToLocaleIds';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class LabelsToLocaleIdsTranslatorFunctionPlugin extends AbstractGenericTranslato
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/LabelsToLocalizedAttributeNamesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/LabelsToLocalizedAttributeNamesTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\LabelsToLocalizedAttributeNames;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class LabelsToLocalizedAttributeNamesTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'LabelsToLocalizedAttributeNames';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class LabelsToLocalizedAttributeNamesTranslatorFunctionPlugin extends AbstractGe
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/LocaleKeysToIdsTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/LocaleKeysToIdsTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\LocaleKeysToIds;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class LocaleKeysToIdsTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'LocaleKeysToIds';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class LocaleKeysToIdsTranslatorFunctionPlugin extends AbstractGenericTranslatorF
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/MarkAsSuperAttributeTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/MarkAsSuperAttributeTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\MarkAsSuperAttribute;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class MarkAsSuperAttributeTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'MarkAsSuperAttribute';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class MarkAsSuperAttributeTranslatorFunctionPlugin extends AbstractGenericTransl
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/MeasureUnitToIntTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/MeasureUnitToIntTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\MeasureUnitToInt;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class MeasureUnitToIntTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'MeasureUnitToInt';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class MeasureUnitToIntTranslatorFunctionPlugin extends AbstractGenericTranslator
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/MoveLocalizedAttributesToAttributesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/MoveLocalizedAttributesToAttributesTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\MoveLocalizedAttributesToAttributes;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class MoveLocalizedAttributesToAttributesTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'MoveLocalizedAttributesToAttributes';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class MoveLocalizedAttributesToAttributesTranslatorFunctionPlugin extends Abstra
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/PriceSelectorTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/PriceSelectorTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\PriceSelector;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class PriceSelectorTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'PriceSelectorTranslatorFunctionPlugin';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class PriceSelectorTranslatorFunctionPlugin extends AbstractGenericTranslatorFun
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/SkipItemsWithoutParentTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/SkipItemsWithoutParentTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\SkipItemsWithoutParent;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class SkipItemsWithoutParentTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'SkipItemsWithoutParent';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class SkipItemsWithoutParentTranslatorFunctionPlugin extends AbstractGenericTran
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/ValuesToAttributesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/ValuesToAttributesTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\ValuesToAttributes;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class ValuesToAttributesTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'ValuesToAttributes';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class ValuesToAttributesTranslatorFunctionPlugin extends AbstractGenericTranslat
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/ValuesToLocalizedAttributesTranslatorFunctionPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/TranslatorFunction/ValuesToLocalizedAttributesTranslatorFunctionPlugin.php
@@ -10,11 +10,22 @@ namespace SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\Plugin\Trans
 use SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\Translator\TranslatorFunction\ValuesToLocalizedAttributes;
 use SprykerMiddleware\Zed\Process\Communication\Plugin\TranslatorFunction\AbstractGenericTranslatorFunctionPlugin;
 
+/**
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
+ */
 class ValuesToLocalizedAttributesTranslatorFunctionPlugin extends AbstractGenericTranslatorFunctionPlugin
 {
+    /**
+     * @var string
+     */
     protected const NAME = 'ValuesToLocalizedAttributes';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -25,6 +36,8 @@ class ValuesToLocalizedAttributesTranslatorFunctionPlugin extends AbstractGeneri
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Validator/ProductAbstractExistValidatorPlugin.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Communication/Plugin/Validator/ProductAbstractExistValidatorPlugin.php
@@ -12,15 +12,30 @@ use SprykerMiddleware\Zed\Process\Communication\Plugin\Validator\AbstractGeneric
 
 /**
  * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Communication\AkeneoPimMiddlewareConnectorCommunicationFactory getFactory()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\AkeneoPimMiddlewareConnectorConfig getConfig()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Persistence\AkeneoPimMiddlewareConnectorQueryContainerInterface getQueryContainer()
+ * @method \SprykerEco\Zed\AkeneoPimMiddlewareConnector\Business\AkeneoPimMiddlewareConnectorFacadeInterface getFacade()
  */
 class ProductAbstractExistValidatorPlugin extends AbstractGenericValidatorPlugin
 {
+    /**
+     * @var string
+     */
     public const NAME = 'ProductAbstractExist';
 
+    /**
+     * @var string
+     */
     public const KEY_NAME = 'name';
+
+    /**
+     * @var string
+     */
     public const KEY_URL = 'url';
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -31,6 +46,8 @@ class ProductAbstractExistValidatorPlugin extends AbstractGenericValidatorPlugin
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return string
@@ -41,6 +58,8 @@ class ProductAbstractExistValidatorPlugin extends AbstractGenericValidatorPlugin
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @param mixed $value

--- a/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Persistence/AkeneoPimMiddlewareConnectorQueryContainer.php
+++ b/src/SprykerEco/Zed/AkeneoPimMiddlewareConnector/Persistence/AkeneoPimMiddlewareConnectorQueryContainer.php
@@ -18,6 +18,8 @@ use Spryker\Zed\Kernel\Persistence\AbstractQueryContainer;
 class AkeneoPimMiddlewareConnectorQueryContainer extends AbstractQueryContainer implements AkeneoPimMiddlewareConnectorQueryContainerInterface
 {
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \Propel\Runtime\ActiveQuery\ModelCriteria
@@ -33,6 +35,8 @@ class AkeneoPimMiddlewareConnectorQueryContainer extends AbstractQueryContainer 
     }
 
     /**
+     * {@inheritDoc}
+     *
      * @api
      *
      * @return \Propel\Runtime\ActiveQuery\ModelCriteria

--- a/tests/SprykerEcoTest/Zed/AkeneoPimMiddlewareConnector/_support/AkeneoPimMiddlewareConnectorZedTester.php
+++ b/tests/SprykerEcoTest/Zed/AkeneoPimMiddlewareConnector/_support/AkeneoPimMiddlewareConnectorZedTester.php
@@ -11,6 +11,7 @@ use Codeception\Actor;
 
 /**
  * Inherited Methods
+ *
  * @method void wantToTest($text)
  * @method void wantTo($text)
  * @method void execute($callable)

--- a/tests/SprykerEcoTest/Zed/AkeneoPimMiddlewareConnector/_support/AkeneoResourceCursorStub/TestResourceCursorStub.php
+++ b/tests/SprykerEcoTest/Zed/AkeneoPimMiddlewareConnector/_support/AkeneoResourceCursorStub/TestResourceCursorStub.php
@@ -11,6 +11,9 @@ use SprykerEco\Service\AkeneoPim\Dependencies\External\Api\Wrapper\AkeneoResourc
 
 class TestResourceCursorStub implements AkeneoResourceCursorInterface
 {
+    /**
+     * @var int
+     */
     protected const PAGE_SIZE = 10;
 
     /**
@@ -51,7 +54,7 @@ class TestResourceCursorStub implements AkeneoResourceCursorInterface
     }
 
     /**
-     * @return int|string
+     * @return string|int
      */
     public function key()
     {

--- a/tests/SprykerEcoTest/Zed/AkeneoPimMiddlewareConnector/_support/Helper/SuperAttributeAkeneoApiStreamPluginHelper.php
+++ b/tests/SprykerEcoTest/Zed/AkeneoPimMiddlewareConnector/_support/Helper/SuperAttributeAkeneoApiStreamPluginHelper.php
@@ -27,12 +27,23 @@ use SprykerMiddleware\Zed\Process\Business\Iterator\NullIterator;
 
 class SuperAttributeAkeneoApiStreamPluginHelper extends Module
 {
+    /**
+     * @var string
+     */
     protected const FAMILY_1_VARIANT_1 = 'family_1_variant_1';
+
+    /**
+     * @var string
+     */
     protected const FAMILY_2_VARIANT_1 = 'family_2_variant_1';
+
+    /**
+     * @var string
+     */
     protected const FAMILY_2_VARIANT_2 = 'family_2_variant_2';
 
     /**
-     * @return string[]
+     * @return array<string>
      */
     public function getExpectedVariantCodes(): array
     {
@@ -150,7 +161,7 @@ class SuperAttributeAkeneoApiStreamPluginHelper extends Module
             $importerPluginMock,
             $importerPluginMock,
             $importerPluginMock,
-            $importerPluginMock
+            $importerPluginMock,
         );
 
         return $streamFactory;


### PR DESCRIPTION
- Developer(s): @abitskil

- Ticket: https://spryker.atlassian.net/browse/CC-33265

- Release Group: https://release.spryker.com/release-groups/view/5356

- merge: merge

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   AkeneoPimMiddlewareConnector  | minor                 | AkeneoPim             |

-----------------------------------------

#### Module AkeneoPimMiddlewareConnector

##### Change log

Adjustments

* Adjusted `AkeneoPimMiddlewareConnectorFacade::getAttributeMapMapperConfig()` to support a new types of attributes `pim_catalog_asset_collection` and `akeneo_reference_entity`.
* Impacted  `AttributeMapMapperStagePlugin` with facade changes.
* Increase the `PHP` version support to 8.1. 
* Increase the `AkeneoPim` module version.

Fixes

* Added missed `Product` module to dependencies.
* Added missed `Url` module to dependencies.
* Added missed `UtilText` module to dependencies.
* Added missed `PropelOrm` module to dependencies.
